### PR TITLE
ci: remove unused env on github action test

### DIFF
--- a/template/.github/workflows/build.yml
+++ b/template/.github/workflows/build.yml
@@ -21,5 +21,3 @@ jobs:
         uses: asdf-vm/actions/plugin-test@v1
         with:
           command: <TOOL CHECK>
-        env:
-          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
asdf GitHub Actions were updated to automatically set the `env` field so no longer is required for simple tasks like the testing in this template. Users can still override as per the docs - https://github.com/asdf-vm/asdf-plugin-template.git

Closes #17 