### PR TITLE
ci: rm scheduled runs, use asdf for lint tool installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,8 +6,6 @@ on:
   push:
     paths-ignore:
       - "**.md"
-  schedule:
-    - cron: "0 0 * * *" # daily at midnight
 
 jobs:
   test:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,8 +6,6 @@ on:
   push:
     paths-ignore:
       - "**.md"
-  schedule:
-    - cron: "0 0 * * *" # daily at midnight
 
 jobs:
   shellcheck:

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+shellcheck 0.7.1
+shfmt 3.2.2

--- a/template/.github/workflows/build.yml
+++ b/template/.github/workflows/build.yml
@@ -6,8 +6,6 @@ on:
   push:
     paths-ignore:
       - "**.md"
-  schedule:
-    - cron: "0 0 * * *" # daily at midnight
 
 jobs:
   plugin_test:

--- a/template/.github/workflows/lint.yml
+++ b/template/.github/workflows/lint.yml
@@ -6,35 +6,21 @@ on:
   push:
     paths-ignore:
       - "**.md"
-  schedule:
-    - cron: "0 0 * * *" # daily at midnight
 
 jobs:
-  shellcheck:
-    name: shellcheck
+  lint:
+    name: Shellcheck and Shell Format
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: Update Shellcheck
-        run: |
-          sudo apt install xz-utils
-          scversion="stable"
-          wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${scversion?}/shellcheck-${scversion?}.linux.x86_64.tar.xz" | tar -xJv
-          sudo cp "shellcheck-${scversion}/shellcheck" /usr/bin/
-          shellcheck --version
+      - name: asdf_install
+        uses: asdf-vm/actions/install@v1
+        with:
+          before_install: bash -c '${ASDF_DATA_DIR:=$HOME/.asdf}/plugins/nodejs/bin/import-release-team-keyring'
       - name: Shellcheck
         run: shellcheck -x bin/* -P lib/
-
-  shfmt:
-    runs-on: macos-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Install shfmt
-        run: brew install shfmt
-
-      - name: Run shfmt
+      - name: Shell Format - List files to check
+        run: shfmt -f .
+      - name: Shell Format - Validate
         run: shfmt -d -i 2 -ci .


### PR DESCRIPTION
- [x] remove scheduled runs from CI pipelines as GitHub will disable Workflows if many executions ocurr without code changes or many consecutive failures. Workflows are disabled for all trigger events, not just the `cron` trigger. This can lead to maintenance burden when maintainers think their pipelines are running when they are not (yet another of my ideas tried and failed :sweat_smile: ).
- [x] use `asdf` action to manage plugin dev and cicd tooling (eg: in `lint.yml`)