### PR TITLE
fix: asdf-direnv compat with bash_source for utils include

### DIFF
--- a/template/bin/install
+++ b/template/bin/install
@@ -2,7 +2,10 @@
 
 set -euo pipefail
 
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
 # shellcheck source=../lib/utils.bash
-source "$(dirname "$0")/../lib/utils.bash"
+source "${plugin_dir}/lib/utils.bash"
 
 install_version "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/template/bin/list-all
+++ b/template/bin/list-all
@@ -2,7 +2,10 @@
 
 set -euo pipefail
 
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
 # shellcheck source=../lib/utils.bash
-source "$(dirname "$0")/../lib/utils.bash"
+source "${plugin_dir}/lib/utils.bash"
 
 list_all_versions | sort_versions | xargs echo


### PR DESCRIPTION
Current direcotry is incorrect when used with tools like `asdf-direnv` and so the plugin commands are not executed properly. This code change is the solution used in other plugins, eg - https://github.com/asdf-vm/asdf-ruby/blob/master/bin/exec-env?rgh-link-date=2021-02-10T05%3A23%3A31Z