### PR TITLE
fix: plugin add command in README.md

### DIFF
--- a/template/README.md
+++ b/template/README.md
@@ -26,7 +26,7 @@ Plugin:
 ```shell
 asdf plugin add <YOUR TOOL>
 # or
-asdf plugin add https://github.com/<YOUR GITHUB USERNAME>/asdf-<YOUR TOOL>.git
+asdf plugin add <YOUR TOOL> https://github.com/<YOUR GITHUB USERNAME>/asdf-<YOUR TOOL>.git
 ```
 
 <YOUR TOOL>:


### PR DESCRIPTION
Can't add plugin without a name

asdf command is `$ asdf plugin add <name> [<git-url>]`