### PR TITLE
ci: Adds missing tools-version file.

### DIFF
--- a/template/.tool-versions
+++ b/template/.tool-versions
@@ -1,0 +1,3 @@
+shellcheck 0.7.1
+shfmt 3.2.2
+nodejs 14.2.0

--- a/template/.tool-versions
+++ b/template/.tool-versions
@@ -1,3 +1,2 @@
 shellcheck 0.7.1
 shfmt 3.2.2
-nodejs 14.2.0

--- a/template/.tool-versions
+++ b/template/.tool-versions
@@ -1,2 +1,2 @@
-shellcheck 0.7.1
-shfmt 3.2.2
+shellcheck 0.7.2
+shfmt 3.2.4


### PR DESCRIPTION
The lint job of the new project will fail in the CI due to the missing tools-version file. The version of the files have been extracted from the root of this repository and the asdf-vm/actions repository.