### PR TITLE
fix: add copyright to template repo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) <YEAR> <YOUR NAME>
+Copyright (c) 2020 The asdf-vm core AUTHORS
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Adds `asdf-vm core AUTHORS` as copyright holders of this repo