### PR TITLE
fix: rename master to main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,7 +39,7 @@ jobs:
           git log
           test ! -d template/
           grep "Apache" LICENSE
-          test "master" = "$(git rev-parse --abbrev-ref HEAD)"
+          test "main" = "$(git rev-parse --abbrev-ref HEAD)"
           ! git grep -F -e "<YOUR TOOL>" \
                    --or -e "<TOOL HOMEPAGE>" \
                    --or -e "<TOOL REPO>" \

--- a/setup.bash
+++ b/setup.bash
@@ -131,7 +131,7 @@ setup_github() {
   license_keyword="${7:-$(ask_license)}"
   license_keyword="$(echo "$license_keyword" | tr '[:upper:]' '[:lower:]')"
 
-  primary_branch="master"
+  primary_branch="main"
 
   cat <<-EOF
 Setting up plugin: asdf-$tool_name
@@ -223,7 +223,7 @@ setup_gitlab() {
   license_keyword="${7:-$(ask_license)}"
   license_keyword="$(echo "$license_keyword" | tr '[:upper:]' '[:lower:]')"
 
-  primary_branch="master"
+  primary_branch="main"
 
   cat <<-EOF
 Setting up plugin: asdf-$tool_name


### PR DESCRIPTION
#24 attempted to support any default branch however we should really just align with GitHub and GitLab defaults which are now `main` instead of `master`.

Closes #40 