### PR TITLE
make the assumed install path part of the var initialization

### DIFF
--- a/template/lib/utils.bash
+++ b/template/lib/utils.bash
@@ -51,7 +51,7 @@ download_release() {
 install_version() {
   local install_type="$1"
   local version="$2"
-  local install_path="$3"
+  local install_path="${3%/bin}/bin"
 
   if [ "$install_type" != "version" ]; then
     fail "asdf-$TOOL_NAME supports release installs only"
@@ -64,7 +64,7 @@ install_version() {
     # TODO: Asert <YOUR TOOL> executable exists.
     local tool_cmd
     tool_cmd="$(echo "$TOOL_TEST" | cut -d' ' -f1)"
-    test -x "$install_path/bin/$tool_cmd" || fail "Expected $install_path/bin/$tool_cmd to be executable."
+    test -x "$install_path/$tool_cmd" || fail "Expected $install_path/$tool_cmd to be executable."
 
     echo "$TOOL_NAME $version installation was successful!"
   ) || (


### PR DESCRIPTION
# Description
The script is assuming `$ASDF_DOWNLOAD_PATH/bin` exists in order to test
for the executable. However, this assumption requires that the `/bin`
portion is specified everywhere.

Seems much easier to default the incoming `$3` arg to assume a `/bin`
upon variable initialization.
