### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,10 +3,11 @@
 This is an [asdf-vm plugin](https://asdf-vm.com/#/plugins-create) template with CI to run [Shellcheck](https://github.com/koalaman/shellcheck) and testing with the [asdf test GitHub Action](https://github.com/asdf-vm/actions).
 ## Usage
 
-1. Create repository based on [this template](https://github.com/asdf-vm/asdf-plugin-template/generate)
-2. Clone locally and run `bash setup.bash`.
-3. Adapt your code following the `TODO` notes on `lib/utils.bash`.
-4. For developing your plugin further, please read [the plugins create section of the docs](https://asdf-vm.com/#/plugins-create).
+1. [Generate](https://github.com/asdf-vm/asdf-plugin-template/generate) a new repository based on this template.
+1. Clone it and run `bash setup.bash`.
+1. Force push to your repo: `git push --force-with-lease`.
+1. Adapt your code at the TODO markers. To find the markers: `grep TODO $(find -type f)`.
+1. To develop your plugin further, please read [the plugins create section of the docs](https://asdf-vm.com/plugins/create.html).
 
 >A feature of this plugin-template when hosted on GitHub is the use of [release-please](https://github.com/googleapis/release-please), an automated release tool. It leverages [Conventional Commit messages](https://www.conventionalcommits.org/) to determine semver release type, see the [documentation](https://github.com/googleapis/release-please).
 
@@ -20,10 +21,10 @@ Contributions welcome!
     asdf plugin add shfmt https://github.com/luizm/asdf-shfmt.git
     asdf install
     ```
-2. Develop!
-3. Lint & Format
+1. Develop!
+1. Lint & Format
     ```shell
     ./scripts/shellcheck.bash
     ./scripts/shfmt.bash
     ```
-4. PR changes
+1. PR changes


### PR DESCRIPTION
Hi! I tried out your plugin template and thought I would contribute a few items.

1. use auto-numbering for lists in README
1. reword the instructions
1. add force push step right after running setup.bash -- otherwise plugin developer might forget and get confused if they try to do a `git pull` before pushing to the repo
1. add a command to find all TODO markers
1. use the correct URL for asdf documentation

Thank you for this great tool!