### PR TITLE
rework last step in setup.bash

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -195,10 +195,19 @@ EOF
 
       printf "All done.\n"
       printf "Your %s branch has been reset to an initial commit.\n" "$primary_branch"
-      printf "Push to origin/%s with \`git push --force-with-lease\`\n" "$primary_branch"
 
-      printf "Review these TODO items:\n"
-      git grep -P -n -C 3 "TODO"
+      ok="${9:-$(ask_for "Push to origin? (yes/no)")}"
+      if [ "yes" != "$ok" ]; then
+        printf "Local repo not pushed.\n"
+        printf "Manually push to origin/%s with \`git push --force-with-lease\`\n" "$primary_branch"
+        printf "Then, find TODO items with \`git grep -n TODO\` and resolve them.\n"
+        printf "Remember to commit and push your changes afterwards.\n"
+      else
+        git push --force-with-lease
+        printf "Done pushing to origin/%s\n" "$primary_branch"
+        printf "Now, find TODO items with \`git grep -n TODO\` and resolve them.\n"
+        printf "Remember to commit and push your changes afterwards.\n"
+      fi
     ) || cd "$cwd"
   fi
 }
@@ -287,10 +296,19 @@ EOF
 
       printf "All done.\n"
       printf "Your %s branch has been reset to an initial commit.\n" "$primary_branch"
-      printf "You might want to push using \`--force-with-lease\` to origin/%s\n" "$primary_branch"
 
-      printf "Showing pending TODO tags that you might want to review\n"
-      git grep -P -n -C 3 "TODO"
+      ok="${9:-$(ask_for "Push to origin? (yes/no)")}"
+      if [ "yes" != "$ok" ]; then
+        printf "Local repo not pushed.\n"
+        printf "Manually push to origin/%s with \`git push --force-with-lease\`\n" "$primary_branch"
+        printf "Then, find TODO items with \`git grep -n TODO\` and resolve them.\n"
+        printf "Remember to commit and push your changes afterwards.\n"
+      else
+        git push --force-with-lease
+        printf "Done pushing to origin/%s\n" "$primary_branch"
+        printf "Now, find TODO items with \`git grep -n TODO\` and resolve them.\n"
+        printf "Remember to commit and push your changes afterwards.\n"
+      fi
     ) || cd "$cwd"
   fi
 }


### PR DESCRIPTION
I'm proposing a few changes to the last step in setup.bash, with rationale:

1. Ask user (developer) to force-push the local repo to the remote.

When I used this script, I had to scroll upwards to find this instruction (and the command to do it). Automating this step means that the developer won't miss it. Also, I think it's a good idea to push the local repo immediately after running the setup script, because the developer won't get confused if they edit the files / scripts later and `git push` fails.

1. Don't automatically show the TODO items.

On my laptop at least, `git grep` does not restore the screen contents after the grep results are closed. Letting the user (developer) do this for themselves gives them a chance to read the instructions before it's pushed out of the visible screen space.

Please let me know if this is not the correct approach, thank you.