### PR TITLE
feat: use tool repo URL as default value for homepage

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -127,7 +127,7 @@ setup_github() {
   author_name="${4:-$(ask_for "Your name" "$(git config user.name 2>/dev/null)")}"
 
   tool_repo="${5:-$(ask_for "$HELP_TOOL_REPO" "https://github.com/$github_username/$tool_name")}"
-  tool_homepage="${6:-$(ask_for "$HELP_TOOL_HOMEPAGE" "https://github.com/$github_username/$tool_name")}"
+  tool_homepage="${6:-$(ask_for "$HELP_TOOL_HOMEPAGE" "$tool_repo")}"
   license_keyword="${7:-$(ask_license)}"
   license_keyword="$(echo "$license_keyword" | tr '[:upper:]' '[:lower:]')"
 
@@ -219,7 +219,7 @@ setup_gitlab() {
 
   github_username="${3:-$(ask_for "Tool GitHub username")}"
   tool_repo="${5:-$(ask_for "$HELP_TOOL_REPO" "https://github.com/$github_username/$tool_name")}"
-  tool_homepage="${6:-$(ask_for "$HELP_TOOL_HOMEPAGE" "https://github.com/$github_username/$tool_name")}"
+  tool_homepage="${6:-$(ask_for "$HELP_TOOL_HOMEPAGE" "$tool_repo")}"
   license_keyword="${7:-$(ask_license)}"
   license_keyword="$(echo "$license_keyword" | tr '[:upper:]' '[:lower:]')"
 


### PR DESCRIPTION
The tool homepage is set to "https://github.com/MY_GITHUB_USERNAME/TOOL_NAME" by default.

When I am the tool author and the plugin author, this is true. However, I see that quite a few plugins are not authored by the same person who authored the tool. I'm proposing this patch to slightly "more intelligently" provide the tool homepage / documentation site, which is the tool's github repo. This does not break the existing use case where the tool author and the plugin author is the same person / GitHub account.