### PR TITLE
fix: delete Why section from toc

### DIFF
--- a/template/README-github.md
+++ b/template/README-github.md
@@ -11,7 +11,6 @@
 
 - [Dependencies](#dependencies)
 - [Install](#install)
-- [Why?](#why)
 - [Contributing](#contributing)
 - [License](#license)
 

--- a/template/README-gitlab.md
+++ b/template/README-gitlab.md
@@ -10,7 +10,6 @@
 
 - [Dependencies](#dependencies)
 - [Install](#install)
-- [Why?](#why)
 - [Contributing](#contributing)
 - [License](#license)
 


### PR DESCRIPTION
This PR deletes `Why?` section from table of contents.