### PR TITLE
fix: future-proof `git read-tree --prefix` call

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -167,7 +167,7 @@ EOF
       cd "$out"
       git checkout --orphan out
       git rm -rf "$out" >/dev/null
-      git read-tree --prefix=/ -u template:template/
+      git read-tree --prefix="" -u template:template/
 
       download_license "$license_keyword" "$out/LICENSE"
       sed -i '1s;^;TODO: INSERT YOUR NAME & COPYRIGHT YEAR\n;g' "$out/LICENSE"


### PR DESCRIPTION
As noted in #53 , recent versions of git will disallow `--prefix=/` in the `git read-tree` command.
This PR changes the prefix flag to `--prefix=""` instead.