### PR TITLE
Add example plugin help documentation

### DIFF
--- a/template/bin/help.links
+++ b/template/bin/help.links
@@ -1,0 +1,5 @@
+# Output should be <title>: <link>
+
+echo 'home-page: https://github.com/$GH_USER/$PLUGIN_NAME
+$TOOL_NAME: $TOOL_PAGE
+'

--- a/template/bin/help.overview
+++ b/template/bin/help.overview
@@ -1,0 +1,10 @@
+# Output should be freeform text. asdf decides how to reformat it.
+
+echo 'Basic usage:
+
+  asdf install $TOOL_NAME latest
+  asdf global $TOOL_NAME latest
+  $TOOL_TEST
+
+Check the asdf documentation for more instructions on how to install and manage versions of $TOOL_NAME.
+'


### PR DESCRIPTION
This change adds `help.links` and `help.overview` so that there's an example of how to get output when running...
```
asdf help <plugin>
```