### PR TITLE
feat: implement latest-stable from GH releases with fallback

### DIFF
--- a/template/bin/latest-stable
+++ b/template/bin/latest-stable
@@ -11,13 +11,13 @@ plugin_dir=$(dirname "$(dirname "$current_script_path")")
 curl_opts=(-sI)
 
 if [ -n "${GITHUB_API_TOKEN:-}" ]; then
-	curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
+  curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
 fi
 
 # curl of REPO/releases/latest is expected to be a 302 to another URL
 # when no releases redirect_url="REPO/releases"
 # when there are releases redirect_url="REPO/releases/tag/v<VERSION>"
-redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|^location: *||p" | 	sed -n -e "s|\r||p")
+redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|^location: *||p" | sed -n -e "s|\r||p")
 version=
 printf "redirect url: %s\n" "$redirect_url"
 if [[ "$redirect_url" == "$GH_REPO/releases" ]]; then

--- a/template/bin/latest-stable
+++ b/template/bin/latest-stable
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+current_script_path=${BASH_SOURCE[0]}
+plugin_dir=$(dirname "$(dirname "$current_script_path")")
+
+# shellcheck source=../lib/utils.bash
+. "${plugin_dir}/lib/utils.bash"
+
+curl_opts=(-sI)
+
+if [ -n "${GITHUB_API_TOKEN:-}" ]; then
+	curl_opts=("${curl_opts[@]}" -H "Authorization: token $GITHUB_API_TOKEN")
+fi
+
+# curl of REPO/releases/latest is expected to be a 302 to another URL
+# when no releases URL="REPO/releases"
+# when there are releases URL="REPO/releases/tag/v<SEMVER_VERSION>"
+redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|^location: *||p" | 	sed -n -e "s|\r||p")
+version=
+printf "redirect url: %s\n" "$redirect_url"
+if [[ "$redirect_url" == "$GH_REPO/releases" ]]; then
+  version="$(list_all_versions | sort_versions | xargs echo | tail -n1)"
+else
+  version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/v||')"
+fi
+
+printf "%s\n" "$version"

--- a/template/bin/latest-stable
+++ b/template/bin/latest-stable
@@ -15,8 +15,8 @@ if [ -n "${GITHUB_API_TOKEN:-}" ]; then
 fi
 
 # curl of REPO/releases/latest is expected to be a 302 to another URL
-# when no releases URL="REPO/releases"
-# when there are releases URL="REPO/releases/tag/v<SEMVER_VERSION>"
+# when no releases redirect_url="REPO/releases"
+# when there are releases redirect_url="REPO/releases/tag/v<VERSION>"
 redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|^location: *||p" | 	sed -n -e "s|\r||p")
 version=
 printf "redirect url: %s\n" "$redirect_url"


### PR DESCRIPTION
This implements the `bin/latest-stable` script which is used to power the `asdf latest <tool>` and `asdf install <tool> latest` commands.

With this implementation we use the GitHub Releases API to query the latest release. If the repository has no releases we fall back to the `list_all` + `tail` behaviour commonly used by plugin authors.

This is a faster solution than the fallback as we do not need to query all tool versions which can sometimes require enumerating many paged endpoints requiring many HTTP requests. This is just one request.