### PR TITLE
fix: redirect log to stderr

### DIFF
--- a/template/bin/latest-stable
+++ b/template/bin/latest-stable
@@ -19,7 +19,7 @@ fi
 # when there are releases redirect_url="REPO/releases/tag/v<VERSION>"
 redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|^location: *||p" | sed -n -e "s|\r||p")
 version=
-printf "redirect url: %s\n" "$redirect_url"
+printf "redirect url: %s\n" "$redirect_url" >&2
 if [[ "$redirect_url" == "$GH_REPO/releases" ]]; then
 	version="$(list_all_versions | sort_versions | xargs echo | tail -n1)"
 else


### PR DESCRIPTION
Otherwise it will break the function [`latest_command`][1] in `.asdf/lib/functions/versions.bash`.

[1]: https://github.com/asdf-vm/asdf/blob/v0.11.3/lib/functions/versions.bash#L144