### PR TITLE
fix: make the sed expression work for non-GNU sed

### DIFF
--- a/template/bin/latest-stable
+++ b/template/bin/latest-stable
@@ -23,7 +23,7 @@ printf "redirect url: %s\n" "$redirect_url" >&2
 if [[ "$redirect_url" == "$GH_REPO/releases" ]]; then
 	version="$(list_all_versions | sort_versions | xargs echo | tail -n1)"
 else
-	version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/v\?||')"
+	version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/v\{0,1\}||')"
 fi
 
 printf "%s\n" "$version"


### PR DESCRIPTION
Use ERE instead, because GitHub Actions doesn't use GNU sed on macOS by default.