### PR TITLE
chore: Improve `.editorconfig` defaults

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,6 +1,12 @@
 root = true
 
 [*]
+indent_style = tab
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.{md,yml,yaml}]
+indent_style = space
+indent_size = 2

--- a/template/.editorconfig
+++ b/template/.editorconfig
@@ -1,6 +1,12 @@
 root = true
 
 [*]
+indent_style = tab
+end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+
+[*.{md,yml,yaml}]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
Currently, when using this repository, files may not match up with user preferences. Both scripts in `template/scripts/*` and `lib/utils.bash` use tabs, but the user may not have that configured and lead to a clashing experience.

Modify the `.editorconfig` file so this doesn't happen.

This also sets `end_of_line` to `lf` as a reasonable default.