### PR TITLE
fix: `bin/latest-stable` return single version not list when no release on GitHub

### DIFF
--- a/template/bin/latest-stable
+++ b/template/bin/latest-stable
@@ -21,7 +21,7 @@ redirect_url=$(curl "${curl_opts[@]}" "$GH_REPO/releases/latest" | sed -n -e "s|
 version=
 printf "redirect url: %s\n" "$redirect_url" >&2
 if [[ "$redirect_url" == "$GH_REPO/releases" ]]; then
-	version="$(list_all_versions | sort_versions | xargs echo | tail -n1)"
+	version="$(list_all_versions | sort_versions | tail -n1 | xargs echo)"
 else
 	version="$(printf "%s\n" "$redirect_url" | sed 's|.*/tag/v\{0,1\}||')"
 fi


### PR DESCRIPTION
While working on my own plugin I have noticed that the fallback logic from `bin/latest-stable` returns list of all releases instead of the last one only. 