### PR TITLE
fix: set proper ShellCheck source for utils.bash

### DIFF
--- a/template/bin/download
+++ b/template/bin/download
@@ -5,7 +5,7 @@ set -euo pipefail
 current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-# shellcheck source=../lib/utils.bash
+# shellcheck source=./lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
 mkdir -p "$ASDF_DOWNLOAD_PATH"

--- a/template/bin/install
+++ b/template/bin/install
@@ -5,7 +5,7 @@ set -euo pipefail
 current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-# shellcheck source=../lib/utils.bash
+# shellcheck source=./lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
 install_version "$ASDF_INSTALL_TYPE" "$ASDF_INSTALL_VERSION" "$ASDF_INSTALL_PATH"

--- a/template/bin/latest-stable
+++ b/template/bin/latest-stable
@@ -5,7 +5,7 @@ set -euo pipefail
 current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-# shellcheck source=../lib/utils.bash
+# shellcheck source=./lib/utils.bash
 . "${plugin_dir}/lib/utils.bash"
 
 curl_opts=(-sI)

--- a/template/bin/list-all
+++ b/template/bin/list-all
@@ -5,7 +5,7 @@ set -euo pipefail
 current_script_path=${BASH_SOURCE[0]}
 plugin_dir=$(dirname "$(dirname "$current_script_path")")
 
-# shellcheck source=../lib/utils.bash
+# shellcheck source=./lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
 list_all_versions | sort_versions | xargs echo


### PR DESCRIPTION
The ShellCheck directive currently points to `../lib/utils.bash`. However, this raises an info log, as ShellCheck is not able to open the file. As the linter runs from the top level of the repository, the right path should be `./lib/utils.bash`.

```
In bin/install line 9:
source "${plugin_dir}/lib/utils.bash"
       ^----------------------------^ SC1091 (info): Not following: ../lib/utils.bash: openBinaryFile: does not exist (No such file or directory)
```