### PR TITLE
fix: correct dependabot directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   # dependabot for GitHub Actions for this repo
   - package-ecosystem: "github-actions"
-    directory: "./github"
+    directory: "/"
     schedule:
       interval: "weekly"
   # dependabot for GitHub Actions for the template

--- a/template/.github/dependabot.yml
+++ b/template/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
   - package-ecosystem: "github-actions"
-    directory: "./github"
+    directory: "/"
     schedule:
       interval: "weekly"


### PR DESCRIPTION
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#directory

Without this change, dependabot does not work as displaying error message as follows

<img width="764" alt="スクリーンショット 2023-07-13 213926" src="https://github.com/asdf-vm/asdf-plugin-template/assets/1180335/b4349e38-80dd-492f-989a-1198ac468c1b">