### PR TITLE
fix: update dependencies in generated README

### DIFF
--- a/template/README-github.md
+++ b/template/README-github.md
@@ -17,7 +17,7 @@
 
 **TODO: adapt this section**
 
-- `bash`, `curl`, `tar`: generic POSIX utilities.
+- `bash`, `curl`, `tar`, and [POSIX utilities](https://pubs.opengroup.org/onlinepubs/9699919799/idx/utilities.html).
 - `SOME_ENV_VAR`: set this environment variable in your shell config to load the correct version of tool x.
 
 # Install

--- a/template/README-gitlab.md
+++ b/template/README-gitlab.md
@@ -17,7 +17,7 @@
 
 **TODO: adapt this section**
 
-- `bash`, `curl`, `tar`: generic POSIX utilities.
+- `bash`, `curl`, `tar`, and [POSIX utilities](https://pubs.opengroup.org/onlinepubs/9699919799/idx/utilities.html).
 - `SOME_ENV_VAR`: set this environment variable in your shell config to load the correct version of tool x.
 
 # Install


### PR DESCRIPTION
The README generated in asdf plugins is written in a way that suggests bash, curl, and tar are POSIX utilities and the only dependencies.

bash, curl and tar are not POSIX utilities, and other POSIX utilities are required.

This change updates the wording, and to help demystify "what is POSIX anyway?" even a little bit, it also links directly to the utility specs of POSIX.