### PR TITLE
chore: bump versions in ci template

### DIFF
--- a/template/.github/workflows/build.yml
+++ b/template/.github/workflows/build.yml
@@ -17,6 +17,6 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: asdf_plugin_test
-        uses: asdf-vm/actions/plugin-test@v2
+        uses: asdf-vm/actions/plugin-test@v3
         with:
           command: <TOOL CHECK>

--- a/template/.github/workflows/lint.yml
+++ b/template/.github/workflows/lint.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: asdf-vm/actions/install@v2
+      - uses: asdf-vm/actions/install@v3
       - run: scripts/lint.bash
 
   actionlint:

--- a/template/.github/workflows/lint.yml
+++ b/template/.github/workflows/lint.yml
@@ -10,14 +10,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: asdf-vm/actions/install@v3
       - run: scripts/lint.bash
 
   actionlint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Check workflow files
         uses: docker://rhysd/actionlint:1.6.23
         with:

--- a/template/.github/workflows/semantic-pr.yml
+++ b/template/.github/workflows/semantic-pr.yml
@@ -11,7 +11,7 @@ jobs:
   semantic-pr:
     runs-on: ubuntu-latest
     steps:
-      - uses: amannn/action-semantic-pull-request@v5.2.0
+      - uses: amannn/action-semantic-pull-request@v5.4.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
- `asdf-vm/actions` from v2 to v3.
- `amannn/action-semantic-pull-request` from v5.2.0 to v5.4.0.
- `actions/checkout` from v3 to v4.