### PR TITLE
fix: git read-tree command for gitlab version

### DIFF
--- a/setup.bash
+++ b/setup.bash
@@ -259,7 +259,7 @@ setup_gitlab() {
 			cd "$out"
 			git checkout --orphan out
 			git rm -rf "$out" >/dev/null
-			git read-tree --prefix=/ -u template:template/
+			git read-tree --prefix="" -u template:template/
 
 			download_license "$license_keyword" "$out/LICENSE"
 


### PR DESCRIPTION
see #53 for a similar fix for the GitHub flow

closes #86 