### PR TITLE
docs: adapt asdf commands to 0.16 breaking changes

### DIFF
--- a/template/README-github.md
+++ b/template/README-github.md
@@ -34,13 +34,13 @@ asdf plugin add <YOUR TOOL> https://github.com/<YOUR GITHUB USERNAME>/asdf-<YOUR
 
 ```shell
 # Show all installable versions
-asdf list-all <YOUR TOOL>
+asdf list all <YOUR TOOL>
 
 # Install specific version
 asdf install <YOUR TOOL> latest
 
 # Set a version globally (on your ~/.tool-versions file)
-asdf global <YOUR TOOL> latest
+asdf set -u <YOUR TOOL> latest
 
 # Now <YOUR TOOL> commands are available
 <TOOL CHECK>

--- a/template/README-gitlab.md
+++ b/template/README-gitlab.md
@@ -34,13 +34,13 @@ asdf plugin add https://gitlab.com/<YOUR GITLAB USERNAME>/asdf-<YOUR TOOL>.git
 
 ```shell
 # Show all installable versions
-asdf list-all <YOUR TOOL>
+asdf list all <YOUR TOOL>
 
 # Install specific version
 asdf install <YOUR TOOL> latest
 
 # Set a version globally (on your ~/.tool-versions file)
-asdf global <YOUR TOOL> latest
+asdf set -u <YOUR TOOL> latest
 
 # Now <YOUR TOOL> commands are available
 <TOOL CHECK>


### PR DESCRIPTION
Newly created templates are still bootstrapping documentation with
pre 0.16 commands.

Backport suggestions from: https://asdf-vm.com/guide/upgrading-to-v0-16.html#breaking-changes

Signed-off-by: Theo Bob Massard <tbobm@protonmail.com>
