### PR TITLE
fix: Allow labeling PRs

### DIFF
--- a/template/.github/workflows/release.yml
+++ b/template/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  issues: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
A freshly generated plugin has a failing release workflow.

> Error: release-please failed: You do not have permission to create labels on this repository.: {"resource":"Repository","field":"label","code":"unauthorized"}

See more: https://github.com/farkasmate/asdf-cloud-provider-kind/actions/runs/15488053270/job/43607251870

`issues: write` permission is now needed:
- https://github.com/googleapis/release-please-action/issues/1105
- https://github.com/googleapis/release-please-action/pull/1108